### PR TITLE
feature/oobaboga: Fixing merge from main (#1911)

### DIFF
--- a/dotnet/src/Connectors/Connectors.AI.Oobabooga/TextCompletion/TextCompletionRequest.cs
+++ b/dotnet/src/Connectors/Connectors.AI.Oobabooga/TextCompletion/TextCompletionRequest.cs
@@ -23,7 +23,7 @@ public sealed class TextCompletionRequest
     /// The maximum number of tokens to generate, ignoring the number of tokens in the prompt.
     /// </summary>
     [JsonPropertyName("max_new_tokens")]
-    public int MaxNewTokens { get; set; }
+    public int? MaxNewTokens { get; set; }
 
     /// <summary>
     /// Determines whether or not to use sampling; use greedy decoding if false.


### PR DESCRIPTION
Hi, this is a new PR from a new user-level fork to account for a github bug preventing edits by maintainers on a PR made from an organization-level fork (see that [final
comment](https://github.com/microsoft/semantic-kernel/pull/1357#issuecomment-1627369158) on last PR)
This PR is only an attempt at merging upstream's main for final integration of the oobabooga connector into main branch. Last set of commits made CompleteRequestSettings.MaxTokens Nullable ([#450f1d3a11eb95d6975da33f581d3997bed42906](https://github.com/microsoft/semantic-kernel/pull/1367)), which broke this connector.
Making TextCompletionRequest.MaxNewTokens also nullable fixed the issue. Note that Oobabooga [defaults max tokens to
200](https://github.com/oobabooga/text-generation-webui/blob/main/extensions/api/util.py#L24)

### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->


### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
